### PR TITLE
Add Seajure to List of Seattle-area Meetups

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -81,6 +81,7 @@
               <li><a href="http://www.meetup.com/Seattle-iPhone-iPad-Android-SURF-Incubator/">Seattle iOS &amp; Android Incubator</a></li>
               <li><a href="http://www.meetup.com/gamedevjs/">Seattle JavaScript Game Development</a></li>
               <li><a href="http://www.meetup.com/seajsws/">Seattle JavaScript Workshop</a></li>
+              <li><a href="http://seajure.github.io/">Seattle Clojure (Seajure)</a></li>
               <li><a href="http://www.meetup.com/Seattle-Node-js/">Seattle Node.js</a></li>
               <li><a href="http://www.meetup.com/php-49/">Seattle PHP</a></li>
               <li><a href="http://www.meetup.com/Seattle-Py/">Seattle Py</a></li>


### PR DESCRIPTION
The Seattle Clojure Group, Seajure, was missing from the list of meetups.
