### PR TITLE
Tagboard office moved a few blocks.

### DIFF
--- a/venues.md
+++ b/venues.md
@@ -2,7 +2,7 @@
 layout: default
 title: Venues for Developer Events
 ---
-Awesome developer events don't happen without an awesome venue with great Wi-Fi. Here is a curated list of spaces in the Seattle-area that are open to hosting meetups, hackathons and other kinds of developer events. 
+Awesome developer events don't happen without an awesome venue with great Wi-Fi. Here is a curated list of spaces in the Seattle-area that are open to hosting meetups, hackathons and other kinds of developer events.
 
 Feel free to [contribute][] more venues, just follow the format you see below. You can use the handy-dandy [static Google map generator][] to build a nice map to include.
 
@@ -15,10 +15,10 @@ Feel free to [contribute][] more venues, just follow the format you see below. Y
 * Website: [http://thehubseattle.com/special-event-space/](http://thehubseattle.com/special-event-space)
 
 ##Tagboard HQ <a name="tagboard"></a>
-![map](http://maps.google.com/maps/api/staticmap?center=47.670907,-122.120891&zoom=15&markers=size:mid|47.673241,-122.123079&path=color:0x0000FF80|weight:5|47.67140,-122.12317&size=500x300&sensor=false)
+![map](http://maps.google.com/maps/api/staticmap?center=47.672118,-122.125532&zoom=14&markers=8201+164th%20Ave%20NE,%20Suite%20105,%20Redmond,%20WA%2098052&size=500x300&sensor=false)
 
 * Location: Redmond (downtown)
-* Address: [7826 Leary Way NE, Suite 201, Redmond, WA 98052](https://maps.google.com/maps?q=7826+Leary+Way+NE,+Redmond,+WA+98052&hl=en&ll=47.673537,-122.123036&spn=0.025343,0.029783&sll=47.67442,-122.122727&sspn=0.810949,0.953064&gl=us&hnear=7826+Leary+Way+NE,+Redmond,+King,+Washington&t=m&z=15)
+* Address: [8201 164th Ave NE, Suite 105, Redmond, WA 98052](https://www.google.com/maps/place/8201+164th+Ave+NE+%23105,+Redmond,+WA+98052/@47.6764526,-122.1219268,17z)
 * Contact: Sean Sperte, sean@tagboard.com
 * Website: [http://tagboard.com/](http://tagboard.com)
 


### PR DESCRIPTION
Still in Redmond, in the Thinkspace building now.